### PR TITLE
New Feature: 🎸 Admin API Routes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cd deno_cloudinary
 3. Next, you can run any of the examples using deno"
 
 ```bash
-deno run --allow-net --allow-env examples/admin_get_resources.ts
+deno run --allow-net --allow-env examples/...
 ```
 
 ### Coding Standards
@@ -51,8 +51,6 @@ TBD/TODO: Test the main client
 
 TBD
 (TODO: Establish Code of Conduct, Contributors Policy)
-
-[Visit the project on GitHub]()
 
 ## License
 

--- a/examples/get_resources.ts
+++ b/examples/get_resources.ts
@@ -1,0 +1,14 @@
+import { Client } from "../mod.ts"
+
+const cloud = new Client({
+    cloud_name: Deno.env.get("CLOUDINARY_CLOUD_NAME"),
+    api_key: Deno.env.get("CLOUDINARY_API_KEY"),
+    api_secret: Deno.env.get("CLOUDINARY_API_SECRETS"),
+    signature_type: 'sha1'
+})
+
+let data = await cloud.getResources({
+    resource_type: 'image'
+});
+
+console.log(data)

--- a/mod.ts
+++ b/mod.ts
@@ -1,0 +1,1 @@
+export { Client } from "./src/Client.ts"

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1,0 +1,102 @@
+import { Base64 } from "https://deno.land/x/bb64/mod.ts";
+
+import { ClientConfig } from "./interfaces/client.interface.ts";
+import {
+  AdminResourceParameters,
+  AdminResourcesResponse,
+  GetResourcesByTagParameters,
+  GetResourcesByContextParameters,
+  ModerationStatusParameters,
+  ResourceDetailsParameters,
+  SearchParameters
+} from "./interfaces/admin.interface.ts";
+import { makeAuthenticatedRequest } from "./lib/fetch.ts";
+import { BaseErrorResponse } from "./interfaces/requests.interface.ts";
+import { generateQueryParams } from "./lib/utils.ts";
+
+export class Client {
+  protected base_url: string = "https://api.cloudinary.com/v1_1/";
+  protected auth_header: string;
+  protected api_url: string;
+  protected sign_payload = (payload: object): Error => {
+    throw new Error("Not Implemented");
+  };
+
+  constructor(config: ClientConfig) {
+    this.auth_header = `Basic ${
+      Base64.fromString(`${config.api_key}:${config.api_secret}`)
+    }`;
+    this.api_url = `${this.base_url}/${config.cloud_name}`;
+  }
+
+  async getResources(
+    params: AdminResourceParameters,
+  ): Promise<AdminResourcesResponse | BaseErrorResponse> {
+    const delivery_type = params.delivery_type || "";
+    const response = await fetch(
+      `${this.api_url}/resources/${params.resource_type}/${delivery_type}`,
+      {
+        headers: [["Authorization", this.auth_header]],
+      },
+    );
+    if(response.ok) return await response.json()
+    return await response.json()
+}
+
+  async getResourcesByTag(
+    params: GetResourcesByTagParameters,
+  ): Promise<AdminResourcesResponse | BaseErrorResponse> {
+    const response = await fetch(
+      `${this.api_url}/resources/${params.resource_type}/tags/${params.tag}`,
+      {
+        headers: [["Authorization", this.auth_header]],
+      },
+    );
+
+    return await response.json();
+  }
+
+  async getResourcesByContext(params: GetResourcesByContextParameters): Promise<AdminResourcesResponse> {
+      const response = await fetch(`${this.api_url}/resources/${params.resource_type}/context/`, {
+          headers: [['Authorization', this.auth_header]]
+      })
+
+
+      return await response.json();
+  };
+
+  async getResourcesByModerationStatus(params:  ModerationStatusParameters): Promise<AdminResourcesResponse> {
+    const response = await fetch(`${this.api_url}/resources/moderations/${params.moderation_kind}/${params.status}`, {
+        headers: [['Authorization', this.auth_header]]
+    })
+
+    return await response.json()
+  }
+
+  async getResourceDetails(params: ResourceDetailsParameters): Promise<AdminResourcesResponse> {
+      const optional_parameters = Object.keys(params).map(param => `${param}=${params[param]}`).join("&")
+
+      return await (
+          await fetch(`${this.api_url}/resources/${params.resource_type}/${params.delivery_type}/${params.public_id}?${optional_parameters}`)
+      ).json()
+  }
+
+    async search(params: SearchParameters): Promise<AdminResourcesResponse> {
+        const request_params = generateQueryParams(params)
+        return await (
+            await fetch(`${this.api_url}/resources/search${request_params}`, {
+                headers: [['Authorization', this.auth_header]]
+            })
+        ).json()
+    }
+
+    async updateDetails(params: ResourceDetailsParameters): Promise<AdminResourcesResponse> {
+        return await (
+            await fetch(`${this.api_url}/resources/${params.resource_type}/${params.delivery_type}/${params.public_id}`, {
+                method: 'POST',
+                headers: [['Authorization', this.auth_header]],
+                body: JSON.stringify(params)
+            })
+        ).json()
+    }
+}

--- a/src/interfaces/admin.interface.ts
+++ b/src/interfaces/admin.interface.ts
@@ -1,0 +1,233 @@
+import { BaseAPIResponseData } from "./base.interface.ts";
+
+export interface IAdminAPI {
+  getResources: Function;
+  getResourcesByTag: Function;
+  getResourcesByContext: Function;
+  getResourcesByModerationStatus: Function;
+  getResourceByPublicId: Function;
+  getResourcesByPublicIds: Function;
+  updateResourceAccess: Function;
+  deleteResources: Function;
+}
+
+export interface AdminResourcesResponse extends BaseAPIResponseData {
+  resources: Array<AdminResource>;
+  next_cursor?: string;
+}
+
+export interface BaseParameterObject {
+    [index: string]: any;
+}
+
+interface AdminOptionalParameters extends BaseParameterObject {
+  moderation?: boolean;
+  direction?: string | number;
+  tags?: boolean;
+  context?: boolean;
+  prefix?: string;
+  public_ids?: Array<string>;
+  max_results?: number;
+  next_cursor?: string;
+  start_at?: string;
+}
+
+interface OptionalResourceDetailsParameters extends AdminOptionalParameters {
+    image_metadata?: boolean;
+    exif?: boolean;
+    faces?: boolean;
+    quality_analysis?: boolean;
+    phash?: boolean;
+    pages?: boolean;
+    derived_next_cursor?: string;
+}
+
+export interface OptionalResourceUpdateDetailsParams extends OptionalResourceDetailsParameters {
+    background_removal: string;
+    categorization: string;
+    raw_convert?: string;
+    ocr?: string;
+    detection?: string;
+    auto_tagging?: number;
+    moderation_status?: string;
+    quality_override?: string;
+    face_coordinates?: string;
+    custom_coordinates?: string;
+    metadata?: string;
+    access_control: Array<object>;
+}
+
+export interface AdminResourceParameters extends AdminOptionalParameters {
+  resource_type: "image" | "raw" | "video" | "auto";
+  delivery_type?: string;
+  public_id?: string;
+  resource_tag?: string;
+}
+
+export interface GetResourcesByTagParameters extends AdminResourceParameters {
+  tag: string;
+}
+
+export interface GetResourcesByContextParameters
+  extends AdminResourceParameters {
+  key: string;
+}
+
+export interface ModerationStatusParameters {
+    moderation_kind: 'metascan' | 'aws_rek' | 'webpurify' | 'manual';
+    status: 'pending' | 'approved' | 'rejected';
+}
+
+export interface ResourceDetailsParameters extends AdminResourceParameters, OptionalResourceDetailsParameters {
+    public_id: string;
+}
+
+export interface OptionalSearchParameters extends AdminOptionalParameters {
+    
+}
+
+export interface AdminResourcePublicIds extends AdminResourceParameters {
+  public_ids?: Array<string>;
+}
+
+export interface AdminModerationParameters extends AdminResourceParameters {
+  moderation_kind?: "metascan" | "aws_rek" | "manual" | "webpurify";
+  moderation_status?: "pending" | "approved" | "rejected";
+}
+
+export interface AdminAccessParameters extends AdminResourceParameters {
+  access_mode: "public" | "authenticated";
+  public_ids?: Array<string>;
+  prefix?: string;
+}
+
+export interface AdminAccessRequestBody {
+  access_mode: "public" | "authenticated";
+  public_ids?: Array<string>;
+  prefix?: string;
+  tag?: string;
+}
+
+export interface AdminResource {
+  public_id: string;
+  format: string;
+  version?: number;
+  resource_type: string;
+  delivery_type?: string | DeliveryType;
+  created_at: string | Date;
+  bytes: number;
+  width?: number;
+  height?: number;
+  backup?: boolean;
+  pixels?: number;
+  access_mode?: string;
+  url: string;
+  secure_url: string;
+  context?: ResouceContext;
+  derived?: Array<ResourceDerivation>;
+  colors?: Array<Array<string | number>>;
+  faces?: Array<Array<number>>;
+  predominant?: object;
+}
+
+export type AccessControl = {
+  access_type: string;
+  start: string;
+  end: string;
+};
+
+interface DeliveryType {}
+
+export interface ResouceContext {
+  custom?: {
+    alt: string;
+    caption: string;
+  };
+}
+
+export interface ResourceDerivation {
+  transformation: string;
+  format: string;
+  bytes: number;
+  id: string;
+  url: string;
+  secure_url: string;
+}
+
+export interface AdminResouceRequestParameters {
+  resource_type: string;
+}
+
+// TODO: More robust typing on access response
+export interface AdminAccessResponse extends BaseAPIResponseData {
+  updated: object;
+  failed: object;
+}
+
+export interface DeleteResourcesParameters extends AdminResourceParameters {
+  public_ids?: Array<string>;
+  prefix?: string;
+  tag?: string;
+  keep_original?: boolean;
+  invalidate?: boolean;
+  next_cursor?: string;
+  transformations?: string;
+}
+
+export type DeleteRequestBody = {
+  public_ids?: Array<string>;
+  prefix?: string;
+  tag?: string;
+  keep_original?: boolean;
+  invalidate?: boolean;
+  next_cursor?: string;
+  transformations?: string;
+};
+
+export interface DeleteResourcesResponse extends BaseAPIResponseData {
+  deleted: object;
+  partial: boolean;
+}
+
+export interface SearchParameters {
+  expression?: string;
+  sort_by?: Array<string>;
+  max_results?: number;
+  next_cursor?: string;
+  with_field?: string;
+  aggregate?: string;
+}
+
+export interface SearchResponse extends BaseAPIResponseData {
+  total_count: number;
+  time: number;
+  aggregations: Aggregations;
+  resources?: Array<SearchResult>;
+}
+
+export interface SearchResult extends AdminResource {
+  backup_bytes?: number;
+  image_analysis?: ImageAnalysis;
+  status?: string;
+  access_control?: Array<AccessControl>;
+  created_by?: {
+    [index: string]: string;
+  };
+  updated_by?: {
+    [index: string]: string;
+  };
+}
+
+interface ImageAnalysis {
+  face_count?: number;
+  faces?: Array<object>;
+  greyscale?: boolean;
+  illustration_score?: number;
+  quality_score?: number;
+  transparent?: boolean;
+  colors: object;
+}
+
+type Aggregations = {
+  format?: object;
+};

--- a/src/interfaces/base.interface.ts
+++ b/src/interfaces/base.interface.ts
@@ -1,0 +1,14 @@
+export interface BaseRequestParameters {}
+
+export interface BaseAPIResponseData {}
+
+interface RequestOptions {
+    method: string;
+    headers: Array<any>
+}
+
+export interface FetchRequestObject {
+    url: string;
+    auth_string: string;
+    options: RequestOptions;
+}

--- a/src/interfaces/client.interface.ts
+++ b/src/interfaces/client.interface.ts
@@ -1,0 +1,12 @@
+export type AuthHeader = {
+    username: string;
+    password: string;
+  };
+  
+  export type ClientConfig = {
+    cloud_name: string | undefined;
+    api_key: string | undefined;
+    api_secret: string | undefined;
+    signature_type: "sha1" | "sha256";
+  };
+  

--- a/src/interfaces/requests.interface.ts
+++ b/src/interfaces/requests.interface.ts
@@ -1,0 +1,9 @@
+export interface BaseErrorResponse {
+    status: number;
+    statusText: string;
+    error: ErrorMessage;
+}
+
+interface ErrorMessage {
+    message: string;
+}

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,0 +1,10 @@
+import { FetchRequestObject } from "../interfaces/base.interface.ts";
+
+export async function makeAuthenticatedRequest(params: FetchRequestObject) {
+    const request_options = {
+        method: params.options.method,
+        headers: [['Authorization', params.auth_string], ...params.options.headers]
+    }
+    return await fetch(params.url, request_options)
+}   
+

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function generateQueryParams(params: any): string {
+    return "?" + Object.keys(params).map(param => `${param}=${params[param]}`).join("&")
+} 


### PR DESCRIPTION
Implemented the following routes:

```

**GET** 
/resources/:resource_type(/:type) | Get resources
resources/:resource_type/tags/:tag | Get resources by tag
/resources/:resource_type/context/ | Get resources by context
/resources/:resource_type/moderations/:moderation_kind/:status | Get resources in moderation queues
/resources/:resource_type/:type/:public_id | Get the details of a single resource
/resources/search | Search for resources

POST
/resources/:resource_type/:type/:public_id | Update details of an existing resource

```